### PR TITLE
Backport patch to include c++ development headers

### DIFF
--- a/.scripts/build_steps.sh
+++ b/.scripts/build_steps.sh
@@ -69,6 +69,13 @@ else
         --suppress-variables ${EXTRA_CB_OPTIONS:-} \
         --clobber-file "${CI_SUPPORT}/clobber_${CONFIG}.yaml" \
         --extra-meta flow_run_id="${flow_run_id:-}" remote_url="${remote_url:-}" sha="${sha:-}"
+
+    ( startgroup "Inspecting artifacts" ) 2> /dev/null
+
+    # inspect_artifacts was only added in conda-forge-ci-setup 4.6.0
+    command -v inspect_artifacts >/dev/null 2>&1 && inspect_artifacts || echo "inspect_artifacts needs conda-forge-ci-setup >=4.6.0"
+
+    ( endgroup "Inspecting artifacts" ) 2> /dev/null
     ( startgroup "Validating outputs" ) 2> /dev/null
 
     validate_recipe_outputs "${FEEDSTOCK_NAME}"

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -8,12 +8,14 @@ package:
 source:
   url: https://github.com/NVIDIA/cudnn-frontend/archive/v{{ version }}.tar.gz
   sha256: 8fa8ef57b7b42a889fcb97ff90c2b0fc171d80468dcf7c7935f0abd9d9757f1b
+  patches:
+    - pyproject_include_headers.patch
 
 build:
   script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
   script_env:
     - CUDNN_FRONTEND_LOG_INFO=1
-  number: 1
+  number: 2
   skip: true           # [cuda_compiler_version in (undefined, "None")]
   skip: true           # [not linux]
 
@@ -40,6 +42,7 @@ test:
     - cudnn
   commands:
     - pip check
+    - python -c "import cudnn; assert cudnn.backend_version() >= 8907"
   requires:
     - pip
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -15,6 +15,7 @@ build:
   script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
   script_env:
     - CUDNN_FRONTEND_LOG_INFO=1
+  string: cuda{{ cuda_compiler_version | replace('.', '') }}py{{ CONDA_PY }}h{{ PKG_HASH }}_{{ PKG_BUILDNUM }}
   number: 2
   skip: true           # [cuda_compiler_version in (undefined, "None")]
   skip: true           # [not linux]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -43,6 +43,8 @@ test:
   commands:
     - pip check
     - python -c "import cudnn; assert cudnn.backend_version() >= 8907"
+    # See if C++ header files are included
+    - ls -lh $PREFIX/lib//python$PY_VER/site-packages/include/*
   requires:
     - pip
 

--- a/recipe/pyproject_include_headers.patch
+++ b/recipe/pyproject_include_headers.patch
@@ -1,0 +1,26 @@
+diff --git a/pyproject.toml b/pyproject.toml
+index 0f10f34..9015e1e 100644
+--- a/pyproject.toml
++++ b/pyproject.toml
+@@ -14,12 +14,16 @@ classifiers = [
+ ]
+
+ [tool.setuptools]
+-packages = ["cudnn"]
+-package-dir = {"" = "python"}
++packages = ["cudnn", "include"]
++package-dir = {"" = "python", "include" = "include"}
++include-package-data = true
+
+ [project.urls]
+ "Homepage" = "https://github.com/nvidia/cudnn-frontend"
+ "Bug Tracker" = "https://github.com/nvidia/cudnn-frontend/issues"
+
+ [tool.setuptools.dynamic]
+-version = {attr = "cudnn.__version__"}
+\ No newline at end of file
++version = {attr = "cudnn.__version__"}
++
++[tool.setuptools.package-data]
++include = ["**/*"]
+\ No newline at end of file


### PR DESCRIPTION
The wheel for cudnn-frontend 1.5 now includes the C++ development headers, so getting the pyproject.toml patch from https://github.com/NVIDIA/cudnn-frontend/pull/81 backported to 1.3 to have the files in https://github.com/NVIDIA/cudnn-frontend/tree/v1.3.0/include packaged as well.

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->

Xref https://github.com/NVIDIA/cudnn-frontend/issues/76