### PR TITLE
fix build strings

### DIFF
--- a/recipe/recipe.yaml
+++ b/recipe/recipe.yaml
@@ -14,7 +14,7 @@ source:
 
 build:
   number: ${{ build_number }}
-  string: cuda${{ cuda_compiler_version | replace('.', '') }}py${{ python | version_to_buildstring }}h${{ hash }}_${{ build_number }}
+  string: cuda${{ cuda_compiler_version | replace('.', '') }}_py${{ python | version_to_buildstring }}_h${{ hash }}_${{ build_number }}
   skip: cuda_compiler_version in (undefined, "None") or (not linux)
   script:
     env:


### PR DESCRIPTION
This project is relying on some conventions that work with `conda-build` but not with schema v1 and `rattler-build`. As a result, the Python version, package hash, and build number are not actually getting included in build strings:

<img width="1069" height="503" alt="Screenshot 2025-12-29 at 11 18 44 PM" src="https://github.com/user-attachments/assets/1d9b4e27-0188-4ee8-ac22-2c91b8ed93cd" />

ref: https://anaconda.org/channels/conda-forge/packages/python-cudnn-frontend/files

This fixes that.

## Notes for Reviewers

I noticed this because I recently started on my first transition to `rattler-build` and worked through similar issues there: https://github.com/conda-forge/lightgbm-feedstock/pull/80#discussion_r2648963552

Thanks for your time and consideration.

### Checklist

* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.